### PR TITLE
‘for循环’部分，range()函数第二版本的说明文字有误

### DIFF
--- a/5-structure-4.ipynb
+++ b/5-structure-4.ipynb
@@ -47,11 +47,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": 1,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2\n",
+      "3\n",
+      "5\n",
+      "7\n"
+     ]
+    }
+   ],
    "source": [
-    "# 请在这里输入代码"
+    "primes = [2, 3, 5, 7]\n",
+    "for prime in primes:\n",
+    "    print(prime)"
    ]
   },
   {
@@ -79,14 +92,14 @@
     "\n",
     "上面的文档说明 `range()` 这个函数有两个版本：第一个接受一个参数；第二个接受三个参数，其中最后一个有缺省值，所以可以不提供（方括号括起来的部分表示有缺省值、可提供可不提供的参数，这个方括号和上面表示列表的不是一回事哦）：\n",
     "* 第一个版本中，唯一的参数是 `range()` 要构造的数列的上限，`range(stop)` 会输出从 `0` 到 `stop-1` 的 整数列；\n",
-    "* 第二个版本中，前两个参数分别是 `range()` 要构造的数列的下限和上限，`range(start, stop)` 会输出从 `start` 到 `stop-1` 的 整数列；如果还提供了第三个参数 `step`，这是等差数列的**公差**，`range(start, stop, step)` 会输出 `[start, start+step, start_step*2,...]` 这样一列整数，最大不超过 `stop-1`。\n",
+    "* 第二个版本中，前两个参数分别是 `range()` 要构造的数列的下限和上限，`range(start, stop)` 会输出从 `start` 到 `stop-1` 的 整数列；如果还提供了第三个参数 `step`，这是等差数列的**公差**，`range(start, stop, step)` 会输出 `[start, start+step, start+step*2,...]` 这样一列整数，最大不超过 `stop-1`。\n",
     "\n",
     "下面是一些例子："
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -104,7 +117,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -113,7 +126,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -122,7 +135,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -138,7 +151,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -168,7 +181,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -211,7 +224,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -227,7 +240,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [


### PR DESCRIPTION
range(start, stop, step)会输出[start, start+step, start+step*2, ...]